### PR TITLE
Setting the imageEncoding and imageQuality needs to be done after sta…

### DIFF
--- a/Myrtille.Web/src/RemoteSessionManager.cs
+++ b/Myrtille.Web/src/RemoteSessionManager.cs
@@ -94,6 +94,9 @@ namespace Myrtille.Web
 
                         // remote session is now connected
                         RemoteSession.State = RemoteSessionState.Connected;
+
+                        SendCommand(RemoteSessionCommand.SetImageEncoding, ((int)_imageEncoding).ToString());
+                        SendCommand(RemoteSessionCommand.SetImageQuality, _imageQuality.ToString());
                     }
                 }
                 // remote clipboard
@@ -401,11 +404,7 @@ namespace Myrtille.Web
             get { return _imageEncoding; }
             set
             {
-                if (_imageEncoding != value)
-                {
-                    _imageEncoding = value;
-                    SendCommand(RemoteSessionCommand.SetImageEncoding, ((int)_imageEncoding).ToString());
-                }
+                _imageEncoding = value;
             }
         }
 
@@ -415,11 +414,7 @@ namespace Myrtille.Web
             get { return _imageQuality; }
             set
             {
-                if (_imageQuality != value)
-                {
-                    _imageQuality = value;
-                    SendCommand(RemoteSessionCommand.SetImageQuality, _imageQuality.ToString());
-                }
+                _imageQuality = value;
             }
         }
 


### PR DESCRIPTION
Setting the imageEncoding and imageQuality needs to be done after state is set to Connected otherwise it is ignored.

As a test i changed imageQuality in config.js to be 10 and nothing happened. This pull request corrects that. Also, it corrects the setup of imageEncoding too.

Please note that now when you set imageEncoding = 'WEBP', myrtille no longer works. My guess is that freeRDP doesn't handle WEBP correctly and noone noticed because of the bug this pull request fixes.