### PR TITLE
UI Improvements

### DIFF
--- a/Myrtille.Web/Default.aspx
+++ b/Myrtille.Web/Default.aspx
@@ -1,4 +1,4 @@
-﻿<%--
+<%--
     Myrtille: A native HTML4/5 Remote Desktop Protocol client.
 
     Copyright (c) 2014-2016 Cedric Coste
@@ -24,7 +24,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml">
-	
+
     <head>
         <!-- force IE out of compatibility mode -->
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
@@ -47,7 +47,7 @@
         <script language="javascript" type="text/javascript" src="js/user/mouse.js"></script>
         <script language="javascript" type="text/javascript" src="js/user/touchscreen.js"></script>
 	</head>
-	
+
     <body onload="startMyrtille(
        '<%=HttpContext.Current.Session.SessionID%>',
         <%=(RemoteSessionManager != null && (RemoteSessionManager.RemoteSession.State == RemoteSessionState.Connecting || RemoteSessionManager.RemoteSession.State == RemoteSessionState.Connected)).ToString(CultureInfo.InvariantCulture).ToLower()%>,
@@ -62,14 +62,52 @@
             <div runat="server" id="controlDiv" class="controlDiv">
 
                 <%-- connection settings --%>
-                <span runat="server" id="serverLabel" class="controlLabel">Server</span><input type="text" runat="server" id="server" class="serverText" title="server address"/>
-                <span runat="server" id="domainLabel" class="controlLabel">Domain (optional)</span><input type="text" runat="server" id="domain" class="domainText" title="user domain"/>
+                <%
+                if(!Boolean.Parse((ConfigurationSettings.AppSettings["HideServer"] == null ? "false" : ConfigurationSettings.AppSettings["HideServer"]))){
+                %>
+                  <span runat="server" id="serverLabel" class="controlLabel">Server</span><input type="text" runat="server" id="server" class="serverText" title="server address" value='<%$ AppSettings:DefaultServerName %>'/>
+                <%
+                }else{
+                %>
+                  <input type="hidden" runat="server" id="server2" class="serverText" title="server address" value='<%$ AppSettings:DefaultServerName %>'/>
+                <%
+                }
+                %>
+                <%
+                if(!Boolean.Parse((ConfigurationSettings.AppSettings["HideDomain"] == null ? "false" : ConfigurationSettings.AppSettings["HideDomain"]))){
+                %>
+                  <span runat="server" id="domainLabel" class="controlLabel">Domain (optional)</span><input type="text" runat="server" id="domain" class="domainText" title="user domain" value='<%$ AppSettings:DefaultDomainName %>'/>
+                <%
+                }else{
+                %>
+                  <input type="hidden" runat="server" id="domain2" class="domainText" title="user domain" value='<%$ AppSettings:DefaultDomainName %>'/>
+                <%
+                }
+                %>
                 <span runat="server" id="userLabel" class="controlLabel">User</span><input type="text" runat="server" id="user" class="userText" title="user name"/>
                 <span runat="server" id="passwordLabel" class="controlLabel">Password</span><input type="password" runat="server" id="password" class="passwordText" title="user password"/>
-                <span runat="server" id="statsLabel" class="controlLabel">Stats</span><select runat="server" id="stat" class="statSelect" title="display stats bar"><option selected="selected">Stat disabled</option><option>Stat enabled</option></select>
-                <span runat="server" id="debugLabel" class="controlLabel">Debug</span><select runat="server" id="debug" class="debugSelect" title="display debug info and save session logs"><option selected="selected">Debug disabled</option><option>Debug enabled</option></select>
+                <%
+                if(!Boolean.Parse((ConfigurationSettings.AppSettings["HideStats"] == null ? "false" : ConfigurationSettings.AppSettings["HideStats"]))){
+                %>
+                  <span runat="server" id="statsLabel" class="controlLabel">Stats</span><select runat="server" id="stat" class="statSelect" title="display stats bar"><option selected="selected">Stat disabled</option><option>Stat enabled</option></select>
+                <%
+                }
+                %>
+                <%
+                if(!Boolean.Parse((ConfigurationSettings.AppSettings["HideDebug"] == null ? "false" : ConfigurationSettings.AppSettings["HideDebug"]))){
+                %>
+                  <span runat="server" id="debugLabel" class="controlLabel">Debug</span><select runat="server" id="debug" class="debugSelect" title="display debug info and save session logs"><option selected="selected">Debug disabled</option><option>Debug enabled</option></select>
+                <%
+                }
+                %>
                 <span runat="server" id="browserLabel" class="controlLabel">Browser</span><select runat="server" id="browser" class="browserSelect" title="rendering mode"><option>HTML4</option><option selected="selected">HTML5</option></select>
-                <span runat="server" id="programLabel" class="controlLabel">Program to run (optional)</span><input type="text" runat="server" id="program" class="programText" title="executable path, name and parameters (double quotes must be escaped)"/>
+                <%
+                if(!Boolean.Parse((ConfigurationSettings.AppSettings["HideProgram"] == null ? "false" : ConfigurationSettings.AppSettings["HideProgram"]))){
+                %>
+                  <span runat="server" id="programLabel" class="controlLabel">Program to run (optional)</span><input type="text" runat="server" id="program" class="programText" title="executable path, name and parameters (double quotes must be escaped)"/>
+                <%
+                }
+                %>
                 <input type="hidden" runat="server" id="width"/>
                 <input type="hidden" runat="server" id="height"/>
                 <input type="submit" runat="server" id="connect" class="connectButton" value="Connect!" onclick="setClientResolution();" onserverclick="ConnectButtonClick" title="open session"/>

--- a/Myrtille.Web/css/Default.css
+++ b/Myrtille.Web/css/Default.css
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Myrtille: A native HTML4/5 Remote Desktop Protocol client.
 
     Copyright(c) 2014-2016 Cedric Coste
@@ -15,6 +15,18 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+
+/* Global Styles */
+
+*{
+  font-family:'Segoe UI';
+}
+
+body{
+    padding:0px;
+    margin:0px;
+    background-color:#34495e;
+}
 
 /* user controls: login screen (before connection) */
 
@@ -34,6 +46,7 @@
     float: left;
     width: 200px;
     margin-top: 2px;
+    color:#ecf0f1;
 }
 
 /* to customize a specific control, remove it below and redefine its css */
@@ -74,6 +87,10 @@
     */
     height: 28px;       /* fixed size */
     overflow: auto;     /* scroll on small displays */
+    position:fixed;
+    top:0px;
+    z-index:1000;
+    background-color:#2980b9;
 }
 
 /* shown info and control */


### PR DESCRIPTION
First off let me say Myrtille is fantastic. I plan on using it in quite a few places to allow for staff remote access.

My only issue with it was that the UI was a bit clunky and it asked too many questions on that first form.

# CSS

I've added a background colour and set the font to an off white.

I've also set the global font to `Segoe UI` to match the Windows UI.

# Defaults & Hiding

In my use case, I only want members of 1 domain to connect to 1 host. Asking them to type in those 2 every time is just asking for problems.

To sort this out I've added a few keys to Config.

The mandatory keys of:

```
    <add key="DefaultServerName" value="rdpserver.domain.local" />
    <add key="DefaultDomainName" value="DOMAIN" />
```

And the optional keys of:

```
    <add key="HideDebug" value="true" />
    <add key="HideDomain" value="true" />
    <add key="HideProgram" value="true" />
    <add key="HideServer" value="true" />
    <add key="HideStats" value="true" />
```

With all this in place my login screen now looks like this:

![image](https://cloud.githubusercontent.com/assets/19609/25699931/3d18c7ac-30bd-11e7-95e9-bb9ab80ee0b1.png)

And the rdp screen looks like this:

![image](https://cloud.githubusercontent.com/assets/19609/25700084/e333a8d2-30bd-11e7-9a18-ec75f6858025.png)