### PR TITLE
Fix for Myrtille.SSH connections to non-default ssh port

### DIFF
--- a/Myrtille.SSH/Program.cs
+++ b/Myrtille.SSH/Program.cs
@@ -244,13 +244,17 @@ namespace Myrtille.SSH
                 if (string.IsNullOrEmpty(Password))
                     throw new SshAuthenticationException("Missing Password");
 
-                var addrParts = ServerAddress.Split(':');
-                var addrHost = addrParts[0];
-                int addrPort;
-                if (addrParts.Length < 2 || !int.TryParse(addrParts[1], out addrPort))
-                    addrPort = 22;
+                Uri serverUri;
+                var serverHost = ServerAddress;
+                var serverPort = 22;
+                if (Uri.TryCreate("tcp://" + ServerAddress, UriKind.Absolute, out serverUri))
+                {
+                    serverHost = serverUri.Host;
+                    if(serverUri.Port > 0)
+                        serverPort = serverUri.Port;
+                }
 
-                var connectionInfo = new ConnectionInfo(addrHost, addrPort, UserName, new PasswordAuthenticationMethod(UserName, Password));
+                var connectionInfo = new ConnectionInfo(serverHost, serverPort, UserName, new PasswordAuthenticationMethod(UserName, Password));
                 connectionInfo.Encoding = Encoding.UTF8;
 
                 client = new SshClient(connectionInfo);

--- a/Myrtille.SSH/Program.cs
+++ b/Myrtille.SSH/Program.cs
@@ -244,7 +244,13 @@ namespace Myrtille.SSH
                 if (string.IsNullOrEmpty(Password))
                     throw new SshAuthenticationException("Missing Password");
 
-                var connectionInfo = new ConnectionInfo(ServerAddress, UserName, new PasswordAuthenticationMethod(UserName, Password));
+                var addrParts = ServerAddress.Split(':');
+                var addrHost = addrParts[0];
+                int addrPort;
+                if (addrParts.Length < 2 || !int.TryParse(addrParts[1], out addrPort))
+                    addrPort = 22;
+
+                var connectionInfo = new ConnectionInfo(addrHost, addrPort, UserName, new PasswordAuthenticationMethod(UserName, Password));
                 connectionInfo.Encoding = Encoding.UTF8;
 
                 client = new SshClient(connectionInfo);


### PR DESCRIPTION
Myrtille.SSH.exe does not work properly when a non-default port is specified via the ServerAddress in host:port format.
Log shows the following as it tries to resolve the host:port combination:
```
2018-09-27 22:26:52,722 [1] ERROR System.Diagnostics redirection [(null)] - Failed to connect ssh client, remote session 3 (System.Net.Sockets.SocketException (0x80004005): No such host is known
   at System.Net.Dns.GetAddrInfo(String name)
   at System.Net.Dns.InternalGetHostByName(String hostName, Boolean includeIPv6)
   at System.Net.Dns.GetHostAddresses(String hostNameOrAddress)
   at Renci.SshNet.Session.SocketConnect(String host, Int32 port)
   at Renci.SshNet.Session.Connect()
   at Renci.SshNet.BaseClient.Connect()
   at Myrtille.SSH.Program.ConnectSSHClient())
```

With this PR the port gets extracted and passed to second parameter of ConnectionInfo:
[http://www.nudoq.org/#!/Packages/SSH.NET/Renci.SshNet/ConnectionInfo/ctor](http://www.nudoq.org/#!/Packages/SSH.NET/Renci.SshNet/ConnectionInfo/ctor)


Thanks for this great Project! 👍 
