### PR TITLE
Better support for remote desktop connection broker

### DIFF
--- a/Myrtille.Services.Contracts/IRemoteSessionProcess.cs
+++ b/Myrtille.Services.Contracts/IRemoteSessionProcess.cs
@@ -41,7 +41,8 @@ namespace Myrtille.Services.Contracts
             int clientHeight,
             bool allowRemoteClipboard,
             bool allowPrintDownload,
-            bool allowAudioPlayback);
+            bool allowAudioPlayback,
+            string loadBalanceInfo);
 
         /// <summary>
         /// stop the host client process

--- a/Myrtille.Services.Contracts/Models/ConnectionInfo.cs
+++ b/Myrtille.Services.Contracts/Models/ConnectionInfo.cs
@@ -36,5 +36,6 @@ namespace Myrtille.Services.Contracts
         /// </summary>
         public string StartProgram { get; set; }
         public string GatewayUrl { get; set; }
+        public string LoadBalanceInfo { get; set; }
     }
 }

--- a/Myrtille.Services/RemoteSessionProcess.cs
+++ b/Myrtille.Services/RemoteSessionProcess.cs
@@ -355,7 +355,7 @@ namespace Myrtille.Services
                         (securityProtocol != SecurityProtocol.auto ? " /sec:" + securityProtocol.ToString() : string.Empty) +       // security protocol
                         (allowAudioPlayback ? " /sound" : string.Empty) +                                                           // sound support
                         " /audio-mode:" + (allowAudioPlayback ? "0" : "2") +                                                        // audio mode (0: redirect, 1: play on server, 2: do not play)
-                        (!string.IsNullOrEmpty(loadBalanceInfo) ? " /load-balance-info:\"" + loadBalanceInfo +"\"" : string.Empty);
+                        (!string.IsNullOrEmpty(loadBalanceInfo) ? " /load-balance-info:\"" + loadBalanceInfo +"\"" : string.Empty); // load balance info from RDS-file
                 }
 
                 #endregion

--- a/Myrtille.Services/RemoteSessionProcess.cs
+++ b/Myrtille.Services/RemoteSessionProcess.cs
@@ -120,7 +120,8 @@ namespace Myrtille.Services
             int clientHeight,
             bool allowRemoteClipboard,
             bool allowPrintDownload,
-            bool allowAudioPlayback)
+            bool allowAudioPlayback,
+            string loadBalanceInfo)
         {
             Trace.TraceInformation("Connecting remote session {0}, type {1}, security {2}, server (:port) {3}, vm {4}, domain {5}, user {6}, program {7}",
                 remoteSessionId,
@@ -353,7 +354,8 @@ namespace Myrtille.Services
                         (allowRemoteClipboard ? " +" : " -") + "clipboard" +                                                        // clipboard support
                         (securityProtocol != SecurityProtocol.auto ? " /sec:" + securityProtocol.ToString() : string.Empty) +       // security protocol
                         (allowAudioPlayback ? " /sound" : string.Empty) +                                                           // sound support
-                        " /audio-mode:" + (allowAudioPlayback ? "0" : "2");                                                         // audio mode (0: redirect, 1: play on server, 2: do not play)
+                        " /audio-mode:" + (allowAudioPlayback ? "0" : "2") +                                                        // audio mode (0: redirect, 1: play on server, 2: do not play)
+                        (!string.IsNullOrEmpty(loadBalanceInfo) ? " /load-balance-info:\"" + loadBalanceInfo +"\"" : string.Empty);
                 }
 
                 #endregion

--- a/Myrtille.Web/Default.aspx
+++ b/Myrtille.Web/Default.aspx
@@ -177,6 +177,11 @@
                     <label id="programLabel" for="program">Program to run (optional)</label>
                     <input type="text" runat="server" id="program" title="executable path, name and parameters (double quotes must be escaped) (optional)"/>
                 </div>
+                
+                <div class="inputDiv" runat="server" Visible="False">
+                    <label id="loadBalanceInfoLabel" for="loadBalanceInfo">Load Balancer Info</label>
+                    <input type="text" runat="server" id="loadBalanceInfo"/>
+                </div>
 
                 <!-- connect -->
                 <input type="submit" runat="server" id="connect" value="Connect!" onserverclick="ConnectButtonClick" title="open session"/>

--- a/Myrtille.Web/Default.aspx.cs
+++ b/Myrtille.Web/Default.aspx.cs
@@ -527,7 +527,7 @@ namespace Myrtille.Web
             var loginUser = user.Value;
             var loginPassword = string.IsNullOrEmpty(passwordHash.Value) ? password.Value : CryptoHelper.RDP_Decrypt(passwordHash.Value);
             var startProgram = program.Value;
-            var loadBalanceInfoValue = loadBalanceInfo.Value;
+            var loadBalanceInfoValue = loadBalanceInfo?.Value;
 
             // allowed features
             var allowRemoteClipboard = _allowRemoteClipboard;
@@ -621,6 +621,8 @@ namespace Myrtille.Web
                     allowAudioPlayback = allowAudioPlayback && connection.AllowAudioPlayback;
 
                     maxActiveGuests = connection.MaxActiveGuests;
+
+                    loadBalanceInfoValue = connection.LoadBalanceInfo;
                 }
                 catch (Exception exc)
                 {

--- a/Myrtille.Web/Default.aspx.cs
+++ b/Myrtille.Web/Default.aspx.cs
@@ -36,7 +36,7 @@ namespace Myrtille.Web
 {
     public partial class Default : Page
     {
-        private MFAAuthenticationClient _mfaAuthClient =  new MFAAuthenticationClient();
+        private MFAAuthenticationClient _mfaAuthClient = new MFAAuthenticationClient();
         private EnterpriseClient _enterpriseClient = new EnterpriseClient();
         private ConnectionClient _connectionClient = new ConnectionClient(Settings.Default.ConnectionServiceUrl);
 
@@ -527,6 +527,7 @@ namespace Myrtille.Web
             var loginUser = user.Value;
             var loginPassword = string.IsNullOrEmpty(passwordHash.Value) ? password.Value : CryptoHelper.RDP_Decrypt(passwordHash.Value);
             var startProgram = program.Value;
+            var loadBalanceInfoValue = loadBalanceInfo.Value;
 
             // allowed features
             var allowRemoteClipboard = _allowRemoteClipboard;
@@ -670,7 +671,8 @@ namespace Myrtille.Web
                     maxActiveGuests,
                     Session.SessionID,
                     (string)Session[HttpSessionStateVariables.ClientKey.ToString()],
-                    Request["cid"] != null
+                    Request["cid"] != null,
+                    loadBalanceInfoValue
                 );
 
                 // bind the remote session to the current http session

--- a/Myrtille.Web/Default.aspx.designer.cs
+++ b/Myrtille.Web/Default.aspx.designer.cs
@@ -7,11 +7,13 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Myrtille.Web {
-    
-    
-    public partial class Default {
-        
+namespace Myrtille.Web
+{
+
+
+    public partial class Default
+    {
+
         /// <summary>
         /// mainForm control.
         /// </summary>
@@ -20,7 +22,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlForm mainForm;
-        
+
         /// <summary>
         /// width control.
         /// </summary>
@@ -29,7 +31,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden width;
-        
+
         /// <summary>
         /// height control.
         /// </summary>
@@ -38,7 +40,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden height;
-        
+
         /// <summary>
         /// login control.
         /// </summary>
@@ -47,7 +49,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl login;
-        
+
         /// <summary>
         /// logo control.
         /// </summary>
@@ -56,7 +58,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl logo;
-        
+
         /// <summary>
         /// hostConnectDiv control.
         /// </summary>
@@ -65,7 +67,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl hostConnectDiv;
-        
+
         /// <summary>
         /// hostType control.
         /// </summary>
@@ -74,7 +76,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlSelect hostType;
-        
+
         /// <summary>
         /// securityProtocol control.
         /// </summary>
@@ -83,7 +85,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlSelect securityProtocol;
-        
+
         /// <summary>
         /// server control.
         /// </summary>
@@ -92,7 +94,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText server;
-        
+
         /// <summary>
         /// vmGuid control.
         /// </summary>
@@ -101,7 +103,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText vmGuid;
-        
+
         /// <summary>
         /// vmEnhancedMode control.
         /// </summary>
@@ -110,7 +112,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputCheckBox vmEnhancedMode;
-        
+
         /// <summary>
         /// domain control.
         /// </summary>
@@ -119,7 +121,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText domain;
-        
+
         /// <summary>
         /// user control.
         /// </summary>
@@ -128,7 +130,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText user;
-        
+
         /// <summary>
         /// password control.
         /// </summary>
@@ -137,7 +139,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputPassword password;
-        
+
         /// <summary>
         /// passwordHash control.
         /// </summary>
@@ -146,7 +148,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden passwordHash;
-        
+
         /// <summary>
         /// mfaDiv control.
         /// </summary>
@@ -155,7 +157,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl mfaDiv;
-        
+
         /// <summary>
         /// mfaProvider control.
         /// </summary>
@@ -164,7 +166,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlAnchor mfaProvider;
-        
+
         /// <summary>
         /// mfaPassword control.
         /// </summary>
@@ -173,7 +175,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText mfaPassword;
-        
+
         /// <summary>
         /// program control.
         /// </summary>
@@ -182,7 +184,16 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText program;
-        
+
+        /// <summary>
+        /// loadBalanceInfo control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlInputText loadBalanceInfo;
+
         /// <summary>
         /// connect control.
         /// </summary>
@@ -191,7 +202,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputSubmit connect;
-        
+
         /// <summary>
         /// adminDiv control.
         /// </summary>
@@ -200,7 +211,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl adminDiv;
-        
+
         /// <summary>
         /// adminUrl control.
         /// </summary>
@@ -209,7 +220,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlAnchor adminUrl;
-        
+
         /// <summary>
         /// adminText control.
         /// </summary>
@@ -218,7 +229,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl adminText;
-        
+
         /// <summary>
         /// connectError control.
         /// </summary>
@@ -227,7 +238,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl connectError;
-        
+
         /// <summary>
         /// hosts control.
         /// </summary>
@@ -236,7 +247,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl hosts;
-        
+
         /// <summary>
         /// enterpriseUserInfo control.
         /// </summary>
@@ -245,7 +256,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText enterpriseUserInfo;
-        
+
         /// <summary>
         /// newRDPHost control.
         /// </summary>
@@ -254,7 +265,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton newRDPHost;
-        
+
         /// <summary>
         /// newSSHHost control.
         /// </summary>
@@ -263,7 +274,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton newSSHHost;
-        
+
         /// <summary>
         /// logout control.
         /// </summary>
@@ -272,7 +283,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton logout;
-        
+
         /// <summary>
         /// hostsList control.
         /// </summary>
@@ -281,7 +292,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Repeater hostsList;
-        
+
         /// <summary>
         /// toolbarToggle control.
         /// </summary>
@@ -290,7 +301,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl toolbarToggle;
-        
+
         /// <summary>
         /// toolbar control.
         /// </summary>
@@ -299,7 +310,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl toolbar;
-        
+
         /// <summary>
         /// serverInfo control.
         /// </summary>
@@ -308,7 +319,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText serverInfo;
-        
+
         /// <summary>
         /// userInfo control.
         /// </summary>
@@ -317,7 +328,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText userInfo;
-        
+
         /// <summary>
         /// scale control.
         /// </summary>
@@ -326,7 +337,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton scale;
-        
+
         /// <summary>
         /// reconnect control.
         /// </summary>
@@ -335,7 +346,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton reconnect;
-        
+
         /// <summary>
         /// keyboard control.
         /// </summary>
@@ -344,7 +355,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton keyboard;
-        
+
         /// <summary>
         /// osk control.
         /// </summary>
@@ -353,7 +364,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton osk;
-        
+
         /// <summary>
         /// clipboard control.
         /// </summary>
@@ -362,7 +373,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton clipboard;
-        
+
         /// <summary>
         /// files control.
         /// </summary>
@@ -371,7 +382,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton files;
-        
+
         /// <summary>
         /// cad control.
         /// </summary>
@@ -380,7 +391,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton cad;
-        
+
         /// <summary>
         /// mrc control.
         /// </summary>
@@ -389,7 +400,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton mrc;
-        
+
         /// <summary>
         /// vswipe control.
         /// </summary>
@@ -398,7 +409,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton vswipe;
-        
+
         /// <summary>
         /// share control.
         /// </summary>
@@ -407,7 +418,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton share;
-        
+
         /// <summary>
         /// disconnect control.
         /// </summary>
@@ -416,7 +427,7 @@ namespace Myrtille.Web {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputButton disconnect;
-        
+
         /// <summary>
         /// imageQuality control.
         /// </summary>

--- a/Myrtille.Web/SendInputs.aspx.cs
+++ b/Myrtille.Web/SendInputs.aspx.cs
@@ -106,7 +106,8 @@ namespace Myrtille.Web
                                 remoteSession.ClientHeight,
                                 remoteSession.AllowRemoteClipboard,
                                 remoteSession.AllowPrintDownload,
-                                remoteSession.AllowAudioPlayback);
+                                remoteSession.AllowAudioPlayback,
+                                remoteSession.LoadBalanceInfo);
                         }
                         catch (Exception exc)
                         {

--- a/Myrtille.Web/src/Clients/RemoteSessionProcessClient.cs
+++ b/Myrtille.Web/src/Clients/RemoteSessionProcessClient.cs
@@ -70,7 +70,8 @@ namespace Myrtille.Web
             int clientHeight,
             bool allowRemoteClipboard,
             bool allowPrintDownload,
-            bool allowAudioPlayback)
+            bool allowAudioPlayback,
+            string loadBalancerInfo)
         {
             Trace.TraceInformation("Calling service start process, remote session {0}, server {1}, domain {2}, user {3}, program {4}", remoteSessionId, serverAddress, string.IsNullOrEmpty(userDomain) ? "(none)" : userDomain, userName, string.IsNullOrEmpty(startProgram) ? "(none)" : startProgram);
 
@@ -91,7 +92,8 @@ namespace Myrtille.Web
                         clientHeight,
                         allowRemoteClipboard,
                         allowPrintDownload,
-                        allowAudioPlayback);
+                        allowAudioPlayback,
+                        loadBalancerInfo);
 
                     _processStarted = true;
                 }

--- a/Myrtille.Web/src/Handlers/RemoteSessionSocketHandler.cs
+++ b/Myrtille.Web/src/Handlers/RemoteSessionSocketHandler.cs
@@ -146,7 +146,8 @@ namespace Myrtille.Web
                         _remoteSession.ClientHeight,
                         _remoteSession.AllowRemoteClipboard,
                         _remoteSession.AllowPrintDownload,
-                        _remoteSession.AllowAudioPlayback);
+                        _remoteSession.AllowAudioPlayback,
+                        _remoteSession.LoadBalanceInfo);
                 }
                 catch (Exception exc)
                 {

--- a/Myrtille.Web/src/RemoteSession.cs
+++ b/Myrtille.Web/src/RemoteSession.cs
@@ -69,6 +69,7 @@ namespace Myrtille.Web
         public bool Reconnect;
         public bool ConnectionService;
         public string ClipboardText;                    // clipboard text
+        public string LoadBalanceInfo;
 
         public RemoteSession(
             Guid id,
@@ -93,7 +94,8 @@ namespace Myrtille.Web
             int maxActiveGuests,
             string ownerSessionID,
             string ownerClientKey,
-            bool connectionService)
+            bool connectionService,
+            string loadBalanceInfoValue)
         {
             Id = id;
             State = RemoteSessionState.NotConnected;
@@ -120,6 +122,7 @@ namespace Myrtille.Web
             OwnerSessionID = ownerSessionID;
             OwnerClientKey = ownerClientKey;
             ConnectionService = connectionService;
+            LoadBalanceInfo = loadBalanceInfoValue;
 
             // default capture API config
             ScreenshotIntervalSecs = 60;


### PR DESCRIPTION
This pull request contains improved support for the remote desktop connection broker using the load balance info from the rdp files (e.g. loadbalanceinfo:s:tsv://MS Terminal Services Plugin.1.RemoteApp). This change utilize the FreeRDP parameter **/load-balance-info** and the value for this parameter can be part of the Auto-Connect URL or a request to the Admin-Services.

**Auto-Connect URL example:** 
https://localhost/Myrtille/?__EVENTTARGET=&__EVENTARGUMENT=&server={server}&user={user}&passwordHash={passwordHash}&program={remoteApp}&loadBalanceInfo=tsv%3A%2F%2FMS%20Terminal%20Services%20Plugin.1.RemoteApp&connect=Connect%21
